### PR TITLE
Fixed Firefox and Edge padding bug

### DIFF
--- a/public/stylesheets/app.css
+++ b/public/stylesheets/app.css
@@ -259,7 +259,7 @@ body {
 /* INFO PANE CSS */
 #info-pane {
   background-color: #ddd;
-  padding: 5px 10px 15px;
+  padding: 5px 10px 0px;
   padding-left: 5px; /* compensate for resizer */
   width: 50%; /* default */
   min-width: 150px;
@@ -277,9 +277,13 @@ body {
 
 /* EVALS PANE CSS */
 #evals-pane {
-  padding: 5px 10px 15px;
+  padding: 5px 10px 0px ;
   overflow-y: auto;
   background-color: #fff;
+}
+
+#evals-comments-body {
+  margin-bottom: 15px;
 }
 
 .flex-eval {
@@ -287,6 +291,10 @@ body {
   display: flex;
   flex-flow: column nowrap;
   justify-content: center;
+}
+
+#disp-classes-body {
+  margin-bottom:15px;
 }
 
 .up-icon {


### PR DESCRIPTION
Firefox and Edge don't display the bottom padding of the flexboxes
Padding is replaced with margin below elements