### PR TITLE
Amend "Preventing importing of courses with invalid catalog numbers"

### DIFF
--- a/importers/importBasicCourseDetails.js
+++ b/importers/importBasicCourseDetails.js
@@ -116,7 +116,7 @@ var importSubject = function (semester, subject) {
       process.stdout.write(' ' + courseData.catalog_number)
     }
 
-    if (typeof (courseData.catalog_number) === 'undefined' || courseData.catalog_number.length < 3) {
+    if (typeof (courseData.catalog_number) === 'undefined' || courseData.catalog_number.length < 2) {
       continue
     }
 


### PR DESCRIPTION
This amends commit d90b0a3334b96268c0f30745bc257c5e81737f8f.

Handles #8 correctly

Closes #89 
  
Reading courses are valid courses with two-digit course numbers between 90 and 99.